### PR TITLE
Add docker support

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:lts
+
+WORKDIR /app
+
+# Install all dependencies.
+COPY package.json ./
+COPY package-lock.json ./
+RUN npm install
+
+COPY public/ ./
+COPY server.js ./
+
+EXPOSE 3000
+ENTRYPOINT ["npm", "run", "start"]

--- a/app/docker-compose.yml
+++ b/app/docker-compose.yml
@@ -5,3 +5,11 @@ services:
       context: ./
     ports:
       - 3000:3000
+    environment:
+      MONGO_URL: "mongodb://mongodb/mirrordb"
+  mongodb:
+    image: mongo:latest
+    volumes:
+      - mongoData:/data/db
+volumes:
+  mongoData:

--- a/app/docker-compose.yml
+++ b/app/docker-compose.yml
@@ -1,0 +1,7 @@
+version: "3.6"
+services:
+  webserver:
+    build:
+      context: ./
+    ports:
+      - 3000:3000

--- a/app/server.js
+++ b/app/server.js
@@ -2,7 +2,7 @@ const express = require("express");
 const mongoose = require("mongoose");
 
 //url param indicates machine mongodb is running on /nameOfDatabase
-mongoose.connect("mongodb://localhost/mirrordb");
+mongoose.connect(process.env.MONGO_URL || "mongodb://localhost/mirrordb");
 
 
 // https://learn.zybooks.com/zybook/UMASSCOMPSCI326RichardsAcademicYear2020/chapter/11/section/8


### PR DESCRIPTION
The webserver isn't currently configured to retry connecting to the database if the first attempt fails, so the database needs to be started first with `docker-compose up mongodb` before starting the webserver with  `docker-compose up webserver`